### PR TITLE
Updated several platforms for 0.7

### DIFF
--- a/dashmachine/platform/curl.py
+++ b/dashmachine/platform/curl.py
@@ -4,10 +4,10 @@
 Curl an URL and show result
 ```ini
 [variable_name]
-platform = curl
-resource = https://example.com
-value_template = {{value}}
-response_type = json
+platform = 'curl'
+resource = 'https://example.com'
+value_template = '{{value}}'
+response_type = 'json'
 ```
 > **Returns:** `value_template` as rendered string
 
@@ -20,21 +20,25 @@ response_type = json
 | response_type   | No       | Response type. Use json if response is a JSON. Default is plain.| plain,json        |
 
 > **Working example:**
->```ini
->[test]
->platform = curl
->resource = https://api.myip.com
->value_template = My IP: {{value.ip}}
-response_type = json
->
+>```config/data_sources.toml
+>[curl_ds]
+>platform = 'curl'
+>resource = 'https://api.myip.com'
+>value_template = 'My IP: {{value.ip}}'
+>response_type = 'json'
+```
+
+
+```
+>Dashboard.toml
 >[MyIp.com]
->prefix = https://
->url = myip.com
->icon = static/images/apps/default.png
->description = Link to myip.com
->open_in = new_tab
->data_sources = test
->```
+>prefix = 'https://'
+>url = 'myip.com'
+>icon = 'static/images/apps/default.png'
+>description = 'Link to myip.com'
+>open_in = 'new_tab'
+>data_sources = 'curl_ds'
+```
 """
 
 import requests
@@ -42,10 +46,10 @@ from flask import render_template_string
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "response_type"):
@@ -55,7 +59,6 @@ class Platform:
         if self.response_type.lower() == "json":
             try:
                 value = requests.get(self.resource).json()
-                print(value)
             except Exception as e:
                 value = f"{e}"
         else:

--- a/dashmachine/platform/docker.py
+++ b/dashmachine/platform/docker.py
@@ -3,11 +3,11 @@
 Display information from Docker API. Informations can be displayed on a custom card or on an app card (e.g. Portainer App)
 ```ini
 [variable_name]
-platform = docker
-prefix = http://
-host = localhost
-port = 2375
-value_template = {{ value_template }}
+platform = 'docker'
+prefix = 'http://'
+host = 'localhost'
+port = '2375'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 | Variable        | Required | Description                                                     | Options           |
@@ -39,62 +39,74 @@ value_template = {{ value_template }}
 * memory
 * warnings
 * error (for debug)
+
 > **Working example (using un-encrypted connection, on Portainer card):**
->```ini
+>```config/data_sources.toml
 > [docker-endpoint-1]
-> platform = docker
-> prefix = http://
-> host = 192.168.0.110
-> port = 2375
-> value_template = {{error}}<p style="text-align:right;text-transform:uppercase;font-size:14px;font-family: monospace;">{{name}}<br /><i style="position: relative; top: .2rem" class="material-icons md-18 theme-success-text" title="Running">fiber_manual_record</i>{{containers_running}}<i style="position: relative; top: .2rem" class="material-icons md-18 theme-warning-text" title="Paused">fiber_manual_record</i>{{containers_paused}}<i style="position: relative; top: .2rem" class="material-icons md-18 theme-failure-text" title="Stopped">fiber_manual_record</i>{{containers_stopped}}</p>
->
+> platform = 'docker'
+> prefix = 'http://'
+> host = '192.168.0.110'
+> port = '2375'
+> value_template = '{{error}}<p style="text-align:right;text-transform:uppercase;font-size:14px;font-family: monospace;">{{name}}<br /><i style="position: relative; top: .2rem; color:green" class="material-icons md-18" title="Running">fiber_manual_record</i>{{containers_running}}<i style="position: relative; top: .2rem; color:yellow" class="material-icons md-18" title="Paused">fiber_manual_record</i>{{containers_paused}}<i style="position: relative; top: .2rem; color:red" class="material-icons md-18" title="Stopped">fiber_manual_record</i>{{containers_stopped}}</p>'
+>```
+
+
+```
+>Dashboard.toml
 > [Portainer]
-> prefix = http://
-> url = 192.168.0.110:2375
-> icon = static/images/apps/portainer.png
-> sidebar_icon = static/images/apps/portainer.png
-> description = Making Docker management easy
-> open_in = this_tab
-> data_sources = docker-endpoint-1
+> prefix = 'http://'
+> url = '192.168.0.110:2375'
+> icon = 'static/images/apps/portainer.png'
+> sidebar_icon = 'static/images/apps/portainer.png'
+> description = 'Making Docker management easy'
+> open_in = 'this_tab'
+> data_sources = 'docker-endpoint-1'
 >```
 >
 >
 > **Working example (using encrypted connection, on Portainer card):**
->```ini
+>```config/data_sources.toml
 > [docker-endpoint-2]
-> platform = docker
-> prefix = https://
-> host = 192.168.0.110
-> port = 2376
-> tls_mode = Both
-> tls_ca = /path/to/ca_file
-> tls_cert = /path/to/cert_file
-> tls_key = /path/to/key_file
-> value_template = {{error}}<p style="text-align:right;text-transform:uppercase;font-size:14px;font-family: monospace;">{{name}}<br /><i style="position: relative; top: .2rem" class="material-icons md-18 theme-success-text" title="Running">fiber_manual_record</i>{{containers_running}}<i style="position: relative; top: .2rem" class="material-icons md-18 theme-warning-text" title="Paused">fiber_manual_record</i>{{containers_paused}}<i style="position: relative; top: .2rem" class="material-icons md-18 theme-failure-text" title="Stopped">fiber_manual_record</i>{{containers_stopped}}</p>
->
-> [Portainer]
-> prefix = http://
-> url = 192.168.0.110:2375
-> icon = static/images/apps/portainer.png
-> sidebar_icon = static/images/apps/portainer.png
-> description = Making Docker management easy
-> open_in = this_tab
-> data_sources = docker-endpoint-2
+> platform = 'docker'
+> prefix = 'https://'
+> host = '192.168.0.110'
+> port = '2376'
+> tls_mode = 'Both'
+> tls_ca = '/path/to/ca_file'
+> tls_cert = '/path/to/cert_file'
+> tls_key = '/path/to/key_file'
+> value_template = '{{error}}<p style="text-align:right;text-transform:uppercase;font-size:14px;font-family: monospace;">{{name}}<br /><i style="position: relative; top: .2rem; color:green" class="material-icons md-18" title="Running">fiber_manual_record</i>{{containers_running}}<i style="position: relative; top: .2rem; color:yellow" class="material-icons md-18" title="Paused">fiber_manual_record</i>{{containers_paused}}<i style="position: relative; top: .2rem; color:red" class="material-icons md-18" title="Stopped">fiber_manual_record</i>{{containers_stopped}}</p>'
 >```
->
->
+
+
+```
+>Dashboard.toml
+> [Portainer]
+> prefix = 'http://'
+> url = '192.168.0.110:2375'
+> icon = 'static/images/apps/portainer.png'
+> sidebar_icon = 'static/images/apps/portainer.png'
+> description = 'Making Docker management easy'
+> open_in = 'this_tab'
+> data_sources = 'docker-endpoint-2'
+>```
+
+
 > **Working example (using un-encrypted connection, on custom Docker card):**
->```ini
+>```config/data_sources.toml
 > [docker-endpoint-3]
-> platform = docker
-> prefix = http://
-> host = 192.168.0.110
-> port = 2375
-> card_type = Custom
->
+> platform = 'docker'
+> prefix = 'http://'
+> host = '192.168.0.110'
+> port = '2375'
+> card_type = 'Custom'
+```
+
+```
+>Dashboard.toml
 > [Docker]
-> type = custom
-> data_sources = docker-endpoint-3
+> type = 'custom'
+> data_sources = 'docker-endpoint-3'
 >```
 """
 
@@ -257,19 +269,19 @@ class Docker(object):
         else:
             if self.tls_mode == None:
                 img_tls = """
-                        <i class="material-icons md-18 theme-warning-text" title="TLS disabled">lock_open</i>
+                        <i class="material-icons md-18" style="color:orange" title="TLS disabled">lock_open</i>
                         """
             else:
                 img_tls = """
-                        <i class="material-icons md-18 theme-success-text" title="TLS enabled">lock</i>
+                        <i class="material-icons md-18" style="color:green" title="TLS enabled">lock</i>
                         """
             if len(self.warnings) > 0:
                 img_warnings = """
-                        <i class="material-icons md-18 theme-warning-text" title="{{warnings}}">warning</i>
+                        <i class="material-icons md-18" style="color:yellow" title="{{warnings}}">warning</i>
                         """
             else:
                 img_warnings = """
-                        <i class="material-icons md-18 theme-muted2-text" title="No warnings">warning</i>
+                        <i class="material-icons md-18" style="color:blue" title="No warnings">warning</i>
                         """
             self.html_template = (
                 """
@@ -312,10 +324,10 @@ class Docker(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "method"):
@@ -387,6 +399,8 @@ class Platform:
                 return "Invalid tls_mode : " + self.tls_mode
 
         self.docker.refresh()
+#        print(self.value_template)
+
 
         if self.card_type == "Custom":
             return render_template_string(self.docker.getHtml(), **self.docker.__dict__)

--- a/dashmachine/platform/healthchecks.py
+++ b/dashmachine/platform/healthchecks.py
@@ -3,14 +3,14 @@
 Display information from Healthchecks API
 ```ini
 [variable_name]
-platform = healthchecks
-prefix = http://
-host = localhost
-port = 8080
-api_key = {{ Healthchecks project API Key }}
-project = {{ Healthchecks project name }}
-verify = true
-value_template = {{ value_template }}
+platform = 'healthchecks'
+prefix = 'http://'
+host = 'localhost'
+port = '8080'
+api_key = '{{ Healthchecks project API Key }}'
+project = '{{ Healthchecks project name }}'
+verify = 'true'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 | Variable        | Required | Description                                                     | Options           |
@@ -33,25 +33,30 @@ value_template = {{ value_template }}
 * count_grace
 * count_paused
 * error (for debug)
+
 > **Working example:**
->```ini
+>```config/data_sources.toml
 > [healthchecks-data]
-> platform = healthchecks
-> prefix = http://
-> host = 192.168.0.110
-> port = 8080
-> api_key = {{ API Key }}
-> project = {{ Project name }}
-> verify = False
-> value_template = {{error}}<p style="text-align:right;text-transform:uppercase;font-size:14px;font-family: monospace;"><i style="position: relative; top: .2rem" class="material-icons md-18 theme-success-text" title="Up">fiber_manual_record</i>{{count_up}}<i style="position: relative; top: .2rem" class="material-icons md-18 theme-warning-text" title="Grace">fiber_manual_record</i>{{count_grace}}<i style="position: relative; top: .2rem" class="material-icons md-18 theme-failure-text" title="Down">fiber_manual_record</i>{{count_down}}</p>
->
+> platform = 'healthchecks'
+> prefix = 'http://'
+> host = '192.168.0.110'
+> port = '8080'
+> api_key = '{{ API Key }}'
+> project = '{{ Project name }}'
+> verify = 'False'
+> value_template = '{{error}}<p style="text-align:right;text-transform:uppercase;font-size:14px;font-family: monospace;"><i style="position: relative; top: .2rem; color:green" class="material-icons md-18" title="Up">fiber_manual_record</i>{{count_up}}<i style="position: relative; top: .2rem; color:yellow" class="material-icons md-18" title="Grace">fiber_manual_record</i>{{count_grace}}<i style="position: relative; top: .2rem; color:red" class="material-icons md-18" title="Down">fiber_manual_record</i>{{count_down}}</p>'
+```
+
+
+```
+>Dashboard.toml
 > [Healthchecks]
-> prefix = http://
-> url  = 192.168.0.110
-> icon = static/images/apps/healthchecks.png
-> description = Healthchecks is a watchdog for your cron jobs. It's a web server that listens for pings from your cron jobs, plus a web interface.
-> open_in = this_tab
-> data_sources = healthchecks-data
+> prefix = 'http://'
+> url  = '192.168.0.110'
+> icon = 'static/images/apps/healthchecks.png'
+> description = 'Healthchecks is a watchdog for your cron jobs. It's a web server that listens for pings from your cron jobs, plus a web interface.'
+> open_in = 'this_tab'
+> data_sources = 'healthchecks-data'
 >```
 """
 
@@ -155,10 +160,10 @@ class Healthchecks(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "method"):

--- a/dashmachine/platform/http_status.py
+++ b/dashmachine/platform/http_status.py
@@ -4,14 +4,14 @@
 Make a http call on a given URL and display if the service is online.
 ```ini
 [variable_name]
-platform = http_status
-resource = https://your-website.com/api
-method = get
-authentication = basic
-username = my_username
-password = my_password
-headers = {"Content-Type": "application/json"}
-return_codes = 2xx,3xx
+platform = 'http_status'
+resource = 'https://your-website.com/api'
+method = 'get'
+authentication = 'basic'
+username = 'my_username'
+password = 'my_password'
+headers = '{"Content-Type": "application/json"}'
+return_codes = '2xx,3xx'
 ```
 > **Returns:** a right-aligned colored bullet point on the app card.
 
@@ -28,18 +28,22 @@ return_codes = 2xx,3xx
 | return_codes    | No       | Acceptable http status codes, x is handled as wildcard          | string            |
 
 > **Working example:**
->```ini
->[http_status_test]
->platform = http_status
->resource = https://google.com
->return_codes = 2xx,3xx
->
+>```config/data_sources.toml
+>[http_status_ds]
+>platform = 'http_status'
+>resource = 'https://google.com'
+>return_codes = '2xx,3xx'
+```
+
+
+```
+>Dashboard.toml
 >[Google]
->prefix = https://
->url = google.com
->icon = static/images/apps/default.png
->open_in = this_tab
->data_sources = http_status_test
+>prefix = 'https://'
+>url = 'google.com'
+>icon = 'static/images/apps/default.png'
+>open_in = 'this_tab'
+>data_sources = 'http_status_ds'
 >```
 
 """
@@ -49,10 +53,11 @@ from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
+
 
         # set defaults for omitted options
         if not hasattr(self, "method"):
@@ -95,8 +100,8 @@ class Platform:
         return_codes = tuple([x.replace("x", "") for x in self.return_codes.split(",")])
 
         if str(resp.status_code).startswith(return_codes):
-            icon_class = "theme-success-text"
+            icon_class = "style='color:green'"
         else:
-            icon_class = "theme-failure-text"
+            icon_class = "style='color:red'"
 
         return f"<i class='material-icons right {icon_class}'>fiber_manual_record </i>"

--- a/dashmachine/platform/pihole.py
+++ b/dashmachine/platform/pihole.py
@@ -4,10 +4,10 @@
 Display information from the PiHole API
 ```ini
 [variable_name]
-platform = pihole
-host = 192.168.1.101
-password = {{ PiHole password }}
-value_template = {{ value_template }}
+platform = 'pihole'
+host = '192.168.1.101'
+password = '{{ PiHole password }}'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 
@@ -36,20 +36,24 @@ value_template = {{ value_template }}
 * gravity_last_updated
 
 > **Working example:**
->```ini
+>```config/data_sources.toml
 > [pihole-data]
-> platform = pihole
-> host = 192.168.1.101
-> password = password123
-> value_template = Ads Blocked Today: {{ blocked }}<br>Status: {{ status }}<br>Queries today: {{ queries }}
->
+> platform = 'pihole'
+> host = '192.168.1.101'
+> password = 'password123'
+> value_template = 'Ads Blocked Today: {{ blocked }}<br>Status: {{ status }}<br>Queries today: {{ queries }}'
+```
+
+
+```
+>Dashboard.toml
 > [PiHole]
-> prefix = http://
-> url = 192.168.1.101
-> icon = static/images/apps/pihole.png
-> description = A black hole for Internet advertisements
-> open_in = new_tab
-> data_sources = pihole-data
+> prefix = 'http://'
+> url = '192.168.1.101'
+> icon = 'static/images/apps/pihole.png'
+> description = 'A black hole for Internet advertisements'
+> open_in = 'new_tab'
+> data_sources = 'pihole-data'
 >```
 """
 
@@ -83,9 +87,10 @@ class PiHole(object):
         self.pw = None
 
     def refresh(self):
-        rawdata = requests.get(
-            "http://" + self.ip_address + "/admin/api.php?summary"
-        ).json()
+        if self.ip_address != None:
+            rawdata = requests.get(
+                "http://" + self.ip_address + "/admin/api.php?summary"
+            ).json()
 
         if self.auth_data != None:
             topdevicedata = requests.get(
@@ -112,18 +117,19 @@ class PiHole(object):
             ).json()["querytypes"]
 
         # Data that is returned is now parsed into vars
-        self.status = rawdata["status"]
-        self.domain_count = rawdata["domains_being_blocked"]
-        self.queries = rawdata["dns_queries_today"]
-        self.blocked = rawdata["ads_blocked_today"]
-        self.ads_percentage = rawdata["ads_percentage_today"]
-        self.unique_domains = rawdata["unique_domains"]
-        self.forwarded = rawdata["queries_forwarded"]
-        self.cached = rawdata["queries_cached"]
-        self.total_clients = rawdata["clients_ever_seen"]
-        self.unique_clients = rawdata["unique_clients"]
-        self.total_queries = rawdata["dns_queries_all_types"]
-        self.gravity_last_updated = rawdata["gravity_last_updated"]
+        if self.ip_address != None:          
+            self.status = rawdata["status"]
+            self.domain_count = rawdata["domains_being_blocked"]
+            self.queries = rawdata["dns_queries_today"]
+            self.blocked = rawdata["ads_blocked_today"]
+            self.ads_percentage = rawdata["ads_percentage_today"]
+            self.unique_domains = rawdata["unique_domains"]
+            self.forwarded = rawdata["queries_forwarded"]
+            self.cached = rawdata["queries_cached"]
+            self.total_clients = rawdata["clients_ever_seen"]
+            self.unique_clients = rawdata["unique_clients"]
+            self.total_queries = rawdata["dns_queries_all_types"]
+            self.gravity_last_updated = rawdata["gravity_last_updated"]
 
     def refreshTop(self, count):
         if self.auth_data == None:
@@ -242,10 +248,16 @@ class PiHole(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
+            
+        #set defaults
+        if not hasattr(self, "host"):
+            self.host = None
+        if not hasattr(self, "password"):
+            self.password = "password123"
 
         self.pihole = PiHole(self.host)
 

--- a/dashmachine/platform/ping.py
+++ b/dashmachine/platform/ping.py
@@ -4,8 +4,8 @@
 Check if a service is online.
 ```ini
 [variable_name]
-platform = ping
-resource = 192.168.1.1
+platform = 'ping'
+resource = '192.168.1.1'
 ```
 > **Returns:** a right-aligned colored bullet point on the app card.
 
@@ -15,6 +15,21 @@ resource = 192.168.1.1
 | platform        | Yes      | Name of the platform.                                           | rest              |
 | resource        | Yes      | Url of whatever you want to ping                                | url               |
 
+> **Working example:**
+>```config/data_sources.toml
+>[ping_ds]
+>platform = 'ping'
+>resource = '192.168.1.1'
+```
+
+
+```
+>Dashboard.toml
+>[custom_card_name]
+>title = 'ping test'
+>data_sources = 'ping_ds'
+>```
+
 
 """
 
@@ -23,10 +38,10 @@ import subprocess
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
     def process(self):
         param = "-n" if platform.system().lower() == "windows" else "-c"
@@ -34,8 +49,8 @@ class Platform:
         up = subprocess.call(command) == 0
 
         if up is True:
-            icon_class = "theme-success-text"
+            icon_class = "style='color:green'"
         else:
-            icon_class = "theme-failure-text"
+            icon_class = "style='color:red'"
 
-        return f"<i class='material-icons right {icon_class}'>fiber_manual_record </i>"
+        return f"<i class='material-icons right' {icon_class} >fiber_manual_record </i>"

--- a/dashmachine/platform/ping.py
+++ b/dashmachine/platform/ping.py
@@ -45,7 +45,7 @@ class Platform:
 
     def process(self):
         param = "-n" if platform.system().lower() == "windows" else "-c"
-        command = ["ping", param, "1", self.resource]
+        command = ["/bin/ping", param, "1", self.resource]
         up = subprocess.call(command) == 0
 
         if up is True:

--- a/dashmachine/platform/weather.py
+++ b/dashmachine/platform/weather.py
@@ -4,12 +4,12 @@
 Weather is a great example of how you can populate a custom card on the dash. This plugin creates a custom card with weather data from [metaweather.com](https://www.metaweather.com)
 ```ini
 [variable_name]
-platform = weather
-woeid = 2514815
-temp_unit = c
-wind_speed_unit = kph
-air_pressure_unit = mbar
-visibility_unit = km
+platform = 'weather'
+woeid = '2514815'
+temp_unit = 'c'
+wind_speed_unit = 'kph'
+air_pressure_unit = 'mbar'
+visibility_unit = 'km'
 ```
 > **Returns:** HTML for custom card
 
@@ -24,14 +24,18 @@ visibility_unit = km
 | visibility_unit   | No       | The unit to be used for visibility                                                                                                       | km,mi             |
 
 > **Working example:**
->```ini
->[variable_name]
->platform = weather
->woeid = 2514815
->
+>```config/data_sources.toml
+>[weather_ds]
+>platform = 'weather'
+>woeid = '2514815'
+```
+
+
+```
+>Dashboard.toml
 >[custom_card_name]
->type = custom
->data_sources = variable_name
+>type = 'custom'
+>data_sources = 'weather_ds'
 >```
 
 """


### PR DESCRIPTION
- Changed the doc and examples to include the ' ' for 0.7.

- Changed on ping.py and http_status the icon_class from "theme-success-text"  to "style='color:red'"

- Changed docker and healthchecks value_template. The icons were all black, not showing the colour (I think because the css file is not present).   I changed the theme-success-text and another two (warning and failure) to have the color inside the style="position.....; color:X"

- Fixed pihole to include the changes i did on my previous PR on 0.6.

- I tested ping, curl, docker, weather and pihole with FLASK. With Gunicorn these also work **except ping**, not sure why (I think because is not reading the subprocess response. Using a raspberry pi with DietPi OS.

- Note that I am running gunicorn as a service, maybe incorrectly.  I got now ping working by modifying the command to /bin/ping, but not sure if that would be compatible across all platforms.