### PR TITLE
Updated for 0.7

### DIFF
--- a/dashmachine/platform/deluge.py
+++ b/dashmachine/platform/deluge.py
@@ -38,7 +38,7 @@ password = 'MySecretPassword'
 >sidebar_icon = 'static/images/apps/deluge.png'
 >description = 'Deluge is a lightweight, Free Software, cross-platform BitTorrent client'
 >open_in = 'iframe'
->data_sources = 'deluge_ds'
+>data_sources.sources = ['deluge_ds']
 >```
 
 """

--- a/dashmachine/platform/deluge.py
+++ b/dashmachine/platform/deluge.py
@@ -4,10 +4,10 @@
 Display information from Deluge web ui.
 ```ini
 [variable_name]
-platform = deluge
-resource = https://deluge.example.com:8112/json
-value_template = ↓{{download_rate|filesizeformat}}/s ↑{{upload_rate|filesizeformat}}/s
-password = MySecretPassword
+platform = 'deluge'
+resource = 'https://deluge.example.com:8112/json'
+value_template = '↓{{download_rate|filesizeformat}}/s ↑{{upload_rate|filesizeformat}}/s'
+password = 'MySecretPassword'
 ```
 > **Returns:** `value_template` as rendered string
 
@@ -20,21 +20,25 @@ password = MySecretPassword
 | password        | No       | Password to use for auth.                                       | string            |
 
 > **Working example:**
->```
->[deluge]
->platform = deluge
->resource = https://deluge.example.com:8112/json
->value_template = ↓{{download_rate|filesizeformat}}/s ↑{{upload_rate|filesizeformat}}/s
->password = MySecretPassword
->
+>```config/data_sources.toml
+>[deluge_ds]
+>platform = 'deluge'
+>resource = 'https://deluge.example.com:8112/json'
+>value_template = '↓{{download_rate|filesizeformat}}/s ↑{{upload_rate|filesizeformat}}/s'
+>password = 'MySecretPassword'
+```
+
+
+```
+>Dashboard.toml
 >[Deluge]
->prefix = https://
->url = https://deluge.example.com:8112
->icon = static/images/apps/deluge.png
->sidebar_icon = static/images/apps/deluge.png
->description = Deluge is a lightweight, Free Software, cross-platform BitTorrent client
->open_in = iframe
->data_sources = deluge
+>prefix = 'https://'
+>url = 'https://deluge.example.com:8112'
+>icon = 'static/images/apps/deluge.png'
+>sidebar_icon = 'static/images/apps/deluge.png'
+>description = 'Deluge is a lightweight, Free Software, cross-platform BitTorrent client'
+>open_in = 'iframe'
+>data_sources = 'deluge_ds'
 >```
 
 """
@@ -44,9 +48,10 @@ import requests
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+    def __init__(self, options):
+        # parse the user's options from the config entries
+        for key, value in options.items():
+            setattr(self, key, value)
 
         if not hasattr(self, "resource"):
             self.resource = "http://localhost/json"

--- a/dashmachine/platform/deluge.py
+++ b/dashmachine/platform/deluge.py
@@ -3,7 +3,7 @@
 ##### deluge
 Display information from Deluge web ui.
 ```ini
-[variable_name]
+['variable_name']
 platform = 'deluge'
 resource = 'https://deluge.example.com:8112/json'
 value_template = '↓{{download_rate|filesizeformat}}/s ↑{{upload_rate|filesizeformat}}/s'
@@ -21,7 +21,7 @@ password = 'MySecretPassword'
 
 > **Working example:**
 >```config/data_sources.toml
->[deluge_ds]
+>['deluge_ds']
 >platform = 'deluge'
 >resource = 'https://deluge.example.com:8112/json'
 >value_template = '↓{{download_rate|filesizeformat}}/s ↑{{upload_rate|filesizeformat}}/s'
@@ -31,7 +31,7 @@ password = 'MySecretPassword'
 
 ```
 >Dashboard.toml
->[Deluge]
+>['Deluge']
 >prefix = 'https://'
 >url = 'https://deluge.example.com:8112'
 >icon = 'static/images/apps/deluge.png'

--- a/dashmachine/platform/lidarr.py
+++ b/dashmachine/platform/lidarr.py
@@ -2,7 +2,7 @@
 ##### Lidarr
 Display information from Lidarr API
 ```ini
-[variable_name]
+['variable_name']
 platform = 'lidarr'
 prefix = 'http://'
 host = 'localhost'
@@ -36,7 +36,7 @@ value_template = '{{ value_template }}'
 * error (for debug)
 > **Working example:**
 >```config/data_sources.toml
-> [lidarr_ds]
+> ['lidarr_ds']
 > platform = 'lidarr'
 > prefix = 'http://'
 > host = '192.168.0.110'
@@ -49,7 +49,7 @@ value_template = '{{ value_template }}'
 
 ```
 >Dashboard.toml
-> [Lidarr]
+> ['Lidarr']
 > prefix = 'http://'
 > url = '192.168.0.110:8686'
 > icon = 'static/images/apps/lidarr.png'

--- a/dashmachine/platform/lidarr.py
+++ b/dashmachine/platform/lidarr.py
@@ -3,13 +3,13 @@
 Display information from Lidarr API
 ```ini
 [variable_name]
-platform = lidarr
-prefix = http://
-host = localhost
-port = 8686
-api_key = my_api_key
-verify = true
-value_template = {{ value_template }}
+platform = 'lidarr'
+prefix = 'http://'
+host = 'localhost'
+port = '8686'
+api_key = 'my_api_key'
+verify = 'true'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 | Variable        | Required | Description                                                     | Options           |
@@ -35,24 +35,28 @@ value_template = {{ value_template }}
 * diskspace[x]['free']
 * error (for debug)
 > **Working example:**
->```ini
-> [lidarr-data]
-> platform = lidarr
-> prefix = http://
-> host = 192.168.0.110
-> port = 8686
-> api_key = {{ API Key }}
-> verify = False
-> value_template = {{error}}Missing : {{wanted_missing}}<br />Queue : {{queue}} <br />Free ({{diskspace[0]['path']}}) : {{diskspace[0]['free']}}
->
+>```config/data_sources.toml
+> [lidarr_ds]
+> platform = 'lidarr'
+> prefix = 'http://'
+> host = '192.168.0.110'
+> port = '8686'
+> api_key = '{{ API Key }}'
+> verify = 'False'
+> value_template = '{{error}}Missing : {{wanted_missing}}<br />Queue : {{queue}} <br />Free ({{diskspace[0]['path']}}) : {{diskspace[0]['free']}}'
+```
+
+
+```
+>Dashboard.toml
 > [Lidarr]
-> prefix = http://
-> url = 192.168.0.110:8686
-> icon = static/images/apps/lidarr.png
-> sidebar_icon = static/images/apps/lidarr.png
-> description = Looks and smells like Sonarr but made for music
-> open_in = this_tab
-> data_sources = lidarr-data
+> prefix = 'http://'
+> url = '192.168.0.110:8686'
+> icon = 'static/images/apps/lidarr.png'
+> sidebar_icon = 'static/images/apps/lidarr.png'
+> description = 'Looks and smells like Sonarr but made for music'
+> open_in = 'this_tab'
+> data_sources = 'lidarr_ds'
 >```
 """
 
@@ -246,10 +250,10 @@ class Lidarr(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "method"):

--- a/dashmachine/platform/lidarr.py
+++ b/dashmachine/platform/lidarr.py
@@ -56,7 +56,7 @@ value_template = '{{ value_template }}'
 > sidebar_icon = 'static/images/apps/lidarr.png'
 > description = 'Looks and smells like Sonarr but made for music'
 > open_in = 'this_tab'
-> data_sources = 'lidarr_ds'
+data_sources.sources = ['lidarr_ds']
 >```
 """
 

--- a/dashmachine/platform/plex.py
+++ b/dashmachine/platform/plex.py
@@ -3,10 +3,10 @@
 Connect to Plex Media Server and see current sessions details
 ```ini
 [variable_name]
-platform = plex
-url = http://plex_host:plex_port
-token = plex_token
-value_template = {{ value_template }}
+platform = 'plex'
+url = 'http://plex_host:plex_port'
+token = 'plex_token'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 | Variable        | Required | Description                                                     | Options           |
@@ -22,20 +22,24 @@ value_template = {{ value_template }}
 * transcodes
 * libraries
 > **Example:**
->```ini
->[plex]
->platform = plex
->host = http://plex.example.com:32400
->token = abcde_fghi_jklmnopqr
->value_template = Sessions: {{sessions}}<br />Transcodes: {{transcodes}}
->
+>```config/data_sources.toml
+>[plex_ds]
+>platform = 'plex'
+>host = 'http://plex.example.com:32400'
+>token = 'abcde_fghi_jklmnopqr'
+>value_template = 'Sessions: {{sessions}}<br />Transcodes: {{transcodes}}'
+```
+
+
+```
+>Dashboard.toml
 >[Plex]
->prefix = http://
->url = plex.example.com:32400
->icon = static/images/apps/plex.png
->description = Plex data sources example
->open_in = this_tab
->data_sources = plex
+>prefix = 'http://'
+>url = 'plex.example.com:32400'
+>icon = 'static/images/apps/plex.png'
+>description = 'Plex data sources example'
+>open_in = 'this_tab'
+>data_sources = 'plex_ds'
 >```
 """
 import requests
@@ -74,10 +78,10 @@ class Plex(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         if not hasattr(self, "token"):
             print(

--- a/dashmachine/platform/plex.py
+++ b/dashmachine/platform/plex.py
@@ -39,7 +39,7 @@ value_template = '{{ value_template }}'
 >icon = 'static/images/apps/plex.png'
 >description = 'Plex data sources example'
 >open_in = 'this_tab'
->data_sources = 'plex_ds'
+>data_sources.sources = ['plex_ds']
 >```
 """
 import requests

--- a/dashmachine/platform/plex.py
+++ b/dashmachine/platform/plex.py
@@ -2,7 +2,7 @@
 ##### Plex Media Server
 Connect to Plex Media Server and see current sessions details
 ```ini
-[variable_name]
+['variable_name']
 platform = 'plex'
 url = 'http://plex_host:plex_port'
 token = 'plex_token'
@@ -23,7 +23,7 @@ value_template = '{{ value_template }}'
 * libraries
 > **Example:**
 >```config/data_sources.toml
->[plex_ds]
+>['plex_ds']
 >platform = 'plex'
 >host = 'http://plex.example.com:32400'
 >token = 'abcde_fghi_jklmnopqr'
@@ -33,7 +33,7 @@ value_template = '{{ value_template }}'
 
 ```
 >Dashboard.toml
->[Plex]
+>['Plex']
 >prefix = 'http://'
 >url = 'plex.example.com:32400'
 >icon = 'static/images/apps/plex.png'

--- a/dashmachine/platform/radarr.py
+++ b/dashmachine/platform/radarr.py
@@ -54,7 +54,7 @@ value_template = '{{ value_template }}'
 > sidebar_icon = 'static/images/apps/radarr.png'
 > description = 'A fork of Sonarr to work with movies à la Couchpotato'
 > open_in = 'this_tab'
-> data_sources = 'radarr_ds'
+> data_sources.sources = ['radarr_ds']
 >```
 """
 

--- a/dashmachine/platform/radarr.py
+++ b/dashmachine/platform/radarr.py
@@ -2,7 +2,7 @@
 ##### Radarr
 Display information from Radarr API
 ```ini
-[variable_name]
+['variable_name']
 platform = 'radarr'
 prefix = 'http://'
 host = 'localhost'
@@ -34,7 +34,7 @@ value_template = '{{ value_template }}'
 * error (for debug)
 > **Working example:**
 >```config/data_sources.toml
-> [radarr_ds]
+> ['radarr_ds']
 > platform = 'radarr'
 > prefix = 'http://'
 > host = '192.168.0.110'
@@ -47,7 +47,7 @@ value_template = '{{ value_template }}'
 
 ```
 >Dashboard.toml
-> [Radarr]
+> ['Radarr']
 > prefix = 'http://'
 > url = '192.168.0.110:7878'
 > icon = 'static/images/apps/radarr.png'

--- a/dashmachine/platform/radarr.py
+++ b/dashmachine/platform/radarr.py
@@ -3,13 +3,13 @@
 Display information from Radarr API
 ```ini
 [variable_name]
-platform = radarr
-prefix = http://
-host = localhost
-port = 7878
-api_key = my_api_key
-verify = true
-value_template = {{ value_template }}
+platform = 'radarr'
+prefix = 'http://'
+host = 'localhost'
+port = '7878'
+api_key = 'my_api_key'
+verify = 'true'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 | Variable        | Required | Description                                                     | Options           |
@@ -33,24 +33,28 @@ value_template = {{ value_template }}
 * diskspace[x]['free']
 * error (for debug)
 > **Working example:**
->```ini
-> [radarr-data]
-> platform = radarr
-> prefix = http://
-> host = 192.168.0.110
-> port = 7878
-> api_key = {{ API Key }}
-> verify = False
-> value_template = {{error}}Movies : {{movies}}<br />Queue : {{queue}} <br />Free ({{diskspace[0]['path']}}) : {{diskspace[0]['free']}}
->
+>```config/data_sources.toml
+> [radarr_ds]
+> platform = 'radarr'
+> prefix = 'http://'
+> host = '192.168.0.110'
+> port = '7878'
+> api_key = '{{ API Key }}'
+> verify = 'False'
+> value_template = '{{error}}Movies : {{movies}}<br />Queue : {{queue}} <br />Free ({{diskspace[0]['path']}}) : {{diskspace[0]['free']}}'
+```
+
+
+```
+>Dashboard.toml
 > [Radarr]
-> prefix = http://
-> url = 192.168.0.110:7878
-> icon = static/images/apps/radarr.png
-> sidebar_icon = static/images/apps/radarr.png
-> description = A fork of Sonarr to work with movies à la Couchpotato
-> open_in = this_tab
-> data_sources = radarr-data
+> prefix = 'http://'
+> url = '192.168.0.110:7878'
+> icon = 'static/images/apps/radarr.png'
+> sidebar_icon = 'static/images/apps/radarr.png'
+> description = 'A fork of Sonarr to work with movies à la Couchpotato'
+> open_in = 'this_tab'
+> data_sources = 'radarr_ds'
 >```
 """
 
@@ -232,10 +236,10 @@ class Radarr(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "method"):

--- a/dashmachine/platform/rest.py
+++ b/dashmachine/platform/rest.py
@@ -36,7 +36,7 @@ verify = 'false'
 >['rest_ds']
 >platform = 'rest'
 >resource = 'https://pokeapi.co/api/v2/pokemon'
->value_template = 'Pokemon: {{value['count']}}'
+>value_template = 'Pokemon: {{value["count"]}}'
 ```
 
 

--- a/dashmachine/platform/rest.py
+++ b/dashmachine/platform/rest.py
@@ -48,7 +48,7 @@ verify = 'false'
 >icon = 'static/images/apps/default.png'
 >description = 'Data sources example'
 >open_in = 'this_tab'
->data_sources = 'rest_ds'
+>data_sources.sources = ['rest_ds']
 >```
 
 """

--- a/dashmachine/platform/rest.py
+++ b/dashmachine/platform/rest.py
@@ -4,16 +4,16 @@
 Make a call on a REST API and display the results as a jinja formatted string.
 ```ini
 [variable_name]
-platform = rest
-resource = https://your-website.com/api
-value_template = {{value}}
-method = post
-authentication = basic
-username = my_username
-password = my_password
-payload = {"var1": "hi", "var2": 1}
-headers = {"Content-Type": "application/json"}
-verify = false
+platform = 'rest'
+resource = 'https://your-website.com/api'
+value_template = '{{value}}'
+method = 'post'
+authentication = 'basic'
+username = 'my_username'
+password = 'my_password'
+payload = '{"var1": "hi", "var2": 1}'
+headers = '{"Content-Type": "application/json"}'
+verify = 'false'
 ```
 > **Returns:** `value_template` as rendered string
 
@@ -32,19 +32,23 @@ verify = false
 | verify          | No       | Turn TLS verification on or off, default is True                | true,false        |
 
 > **Working example:**
->```ini
->[test]
->platform = rest
->resource = https://pokeapi.co/api/v2/pokemon
->value_template = Pokemon: {{value['count']}}
->
+>```config/data_sources.toml
+>[rest_ds]
+>platform = 'rest'
+>resource = 'https://pokeapi.co/api/v2/pokemon'
+>value_template = 'Pokemon: {{value['count']}}'
+```
+
+
+```
+>Dashboard.toml
 >[Pokemon]
->prefix = https://
->url = pokemon.com
->icon = static/images/apps/default.png
->description = Data sources example
->open_in = this_tab
->data_sources = test
+>prefix = 'https://'
+>url = 'pokemon.com'
+>icon = 'static/images/apps/default.png'
+>description = 'Data sources example'
+>open_in = 'this_tab'
+>data_sources = 'rest_ds'
 >```
 
 """
@@ -54,14 +58,14 @@ from requests import get, post
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from flask import render_template_string
 
-
+            
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
+        for key, value in options.items():
             if key == "headers":
                 value = json.loads(value)
-            self.__dict__[key] = value
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "method"):

--- a/dashmachine/platform/rest.py
+++ b/dashmachine/platform/rest.py
@@ -3,7 +3,7 @@
 ##### rest
 Make a call on a REST API and display the results as a jinja formatted string.
 ```ini
-[variable_name]
+['variable_name']
 platform = 'rest'
 resource = 'https://your-website.com/api'
 value_template = '{{value}}'
@@ -33,7 +33,7 @@ verify = 'false'
 
 > **Working example:**
 >```config/data_sources.toml
->[rest_ds]
+>['rest_ds']
 >platform = 'rest'
 >resource = 'https://pokeapi.co/api/v2/pokemon'
 >value_template = 'Pokemon: {{value['count']}}'
@@ -42,7 +42,7 @@ verify = 'false'
 
 ```
 >Dashboard.toml
->[Pokemon]
+>['Pokemon']
 >prefix = 'https://'
 >url = 'pokemon.com'
 >icon = 'static/images/apps/default.png'

--- a/dashmachine/platform/sonarr.py
+++ b/dashmachine/platform/sonarr.py
@@ -3,13 +3,13 @@
 Display information from Sonarr API
 ```ini
 [variable_name]
-platform = sonarr
-prefix = http://
-host = localhost
-port = 8989
-api_key = {{ Sonarr API Key }}
-verify = true
-value_template = {{ value_template }}
+platform = 'sonarr'
+prefix = 'http://'
+host = 'localhost'
+port = '8989'
+api_key = '{{ Sonarr API Key }}'
+verify = 'true'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 | Variable        | Required | Description                                                     | Options           |
@@ -33,24 +33,28 @@ value_template = {{ value_template }}
 * diskspace[x]['free']
 * error (for debug)
 > **Working example:**
->```ini
-> [sonarr-data]
-> platform = sonarr
-> prefix = http://
-> host = 192.168.0.110
-> port = 8989
-> api_key = {{ API Key }}
-> verify = False
-> value_template = {{error}}Missing : {{wanted_missing}}<br />Queue : {{queue}} <br />Free ({{diskspace[0]['path']}}) : {{diskspace[0]['free']}}
->
+>```config/data_sources.toml
+> [sonarr_ds]
+> platform = 'sonarr'
+> prefix = 'http://'
+> host = '192.168.0.110'
+> port = '8989'
+> api_key = '{{ API Key }}'
+> verify = 'False'
+> value_template = '{{error}}Missing : {{wanted_missing}}<br />Queue : {{queue}} <br />Free ({{diskspace[0]['path']}}) : {{diskspace[0]['free']}}'
+```
+
+
+```
+>Dashboard.toml
 > [Sonarr]
-> prefix = http://
-> url = 192.168.0.110:8989
-> icon = static/images/apps/sonarr.png
-> sidebar_icon = static/images/apps/sonarr.png
-> description = Smart PVR for newsgroup and bittorrent users
-> open_in = this_tab
-> data_sources = sonarr-data
+> prefix = 'http://'
+> url = '192.168.0.110:8989'
+> icon = 'static/images/apps/sonarr.png'
+> sidebar_icon = 'static/images/apps/sonarr.png'
+> description = 'Smart PVR for newsgroup and bittorrent users'
+> open_in = 'this_tab'
+> data_sources = 'sonarr_ds'
 >```
 """
 
@@ -232,10 +236,10 @@ class Sonarr(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "method"):

--- a/dashmachine/platform/sonarr.py
+++ b/dashmachine/platform/sonarr.py
@@ -2,7 +2,7 @@
 ##### Sonarr
 Display information from Sonarr API
 ```ini
-[variable_name]
+['variable_name']
 platform = 'sonarr'
 prefix = 'http://'
 host = 'localhost'
@@ -34,7 +34,7 @@ value_template = '{{ value_template }}'
 * error (for debug)
 > **Working example:**
 >```config/data_sources.toml
-> [sonarr_ds]
+> ['sonarr_ds']
 > platform = 'sonarr'
 > prefix = 'http://'
 > host = '192.168.0.110'
@@ -47,7 +47,7 @@ value_template = '{{ value_template }}'
 
 ```
 >Dashboard.toml
-> [Sonarr]
+> ['Sonarr']
 > prefix = 'http://'
 > url = '192.168.0.110:8989'
 > icon = 'static/images/apps/sonarr.png'

--- a/dashmachine/platform/sonarr.py
+++ b/dashmachine/platform/sonarr.py
@@ -54,7 +54,7 @@ value_template = '{{ value_template }}'
 > sidebar_icon = 'static/images/apps/sonarr.png'
 > description = 'Smart PVR for newsgroup and bittorrent users'
 > open_in = 'this_tab'
-> data_sources = 'sonarr_ds'
+> data_sources.sources = ['sonarr_ds']
 >```
 """
 

--- a/dashmachine/platform/tautulli.py
+++ b/dashmachine/platform/tautulli.py
@@ -55,7 +55,7 @@ value_template = '{{ value_template }}'
 > sidebar_icon = 'static/images/apps/tautulli.png'
 > description = 'A Python based monitoring and tracking tool for Plex Media Server'
 > open_in = 'this_tab'
-> data_sources = 'tautulli_ds'
+> data_sources.sources = ['tautulli_ds']
 >```
 """
 

--- a/dashmachine/platform/tautulli.py
+++ b/dashmachine/platform/tautulli.py
@@ -2,7 +2,7 @@
 ##### Tautulli
 Display information from Tautulli API
 ```ini
-[variable_name]
+['variable_name']
 platform = 'tautulli'
 prefix = 'http://'
 host = 'localhost'
@@ -35,7 +35,7 @@ value_template = '{{ value_template }}'
 * error (for debug)
 > **Working example:**
 >```config/data_sources.toml
-> [tautulli_ds]
+> ['tautulli_ds']
 > platform = 'tautulli'
 > prefix = 'http://'
 > host = '192.168.0.110'
@@ -48,7 +48,7 @@ value_template = '{{ value_template }}'
 
 ```
 >Dashboard.toml
-> [Tautulli]
+> ['Tautulli']
 > prefix = 'http://'
 > url = '192.168.0.110:8181'
 > icon = 'static/images/apps/tautulli.png'

--- a/dashmachine/platform/tautulli.py
+++ b/dashmachine/platform/tautulli.py
@@ -3,13 +3,13 @@
 Display information from Tautulli API
 ```ini
 [variable_name]
-platform = tautulli
-prefix = http://
-host = localhost
-port = 8181
-api_key = {{ Tautulli API Key }}
-verify = true
-value_template = {{ value_template }}
+platform = 'tautulli'
+prefix = 'http://'
+host = 'localhost'
+port = '8181'
+api_key = '{{ Tautulli API Key }}'
+verify = 'true'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 | Variable        | Required | Description                                                     | Options           |
@@ -34,24 +34,28 @@ value_template = {{ value_template }}
 * update_message
 * error (for debug)
 > **Working example:**
->```ini
-> [tautulli-data]
-> platform = tautulli
-> prefix = http://
-> host = 192.168.0.110
-> port = 8181
-> api_key = myApiKey
-> verify = False
-> value_template = {{error}}Active sessions : {{stream_count}}
->
+>```config/data_sources.toml
+> [tautulli_ds]
+> platform = 'tautulli'
+> prefix = 'http://'
+> host = '192.168.0.110'
+> port = '8181'
+> api_key = 'myApiKey'
+> verify = 'False'
+> value_template = '{{error}}Active sessions : {{stream_count}}'
+```
+
+
+```
+>Dashboard.toml
 > [Tautulli]
-> prefix = http://
-> url = 192.168.0.110:8181
-> icon = static/images/apps/tautulli.png
-> sidebar_icon = static/images/apps/tautulli.png
-> description = A Python based monitoring and tracking tool for Plex Media Server
-> open_in = this_tab
-> data_sources = tautulli-data
+> prefix = 'http://'
+> url = '192.168.0.110:8181'
+> icon = 'static/images/apps/tautulli.png'
+> sidebar_icon = 'static/images/apps/tautulli.png'
+> description = 'A Python based monitoring and tracking tool for Plex Media Server'
+> open_in = 'this_tab'
+> data_sources = 'tautulli_ds'
 >```
 """
 
@@ -188,10 +192,10 @@ class Tautulli(object):
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         # set defaults for omitted options
         if not hasattr(self, "method"):

--- a/dashmachine/platform/transmission.py
+++ b/dashmachine/platform/transmission.py
@@ -52,7 +52,7 @@ value_template = '{{ value_template }}'
 > icon = 'static/images/apps/transmission.png'
 > description = 'A Fast, Easy, and Free BitTorrent Client'
 > open_in = 'new_tab'
-> data_sources = 'transmission_ds'
+> data_sources.sources = ['transmission_ds']
 >```
 """
 

--- a/dashmachine/platform/transmission.py
+++ b/dashmachine/platform/transmission.py
@@ -3,7 +3,7 @@
 ##### Transmission
 Display information from the Trasnmission API
 ```ini
-[variable_name]
+['variable_name']
 platform = 'transmission'
 host = 'localhost'
 port = '9091'
@@ -34,7 +34,7 @@ value_template = '{{ value_template }}'
 
 > **Working example:**
 >```config/data_sources.toml
-> [transmission_ds]
+> ['transmission_ds']
 > platform = 'transmission'
 > host = '192.168.1.30'
 > port = '9091'
@@ -46,7 +46,7 @@ value_template = '{{ value_template }}'
 
 ```
 >Dashboard.toml
-> [Transmission]
+> ['Transmission']
 > prefix = 'http://'
 > url = '192.168.1.30:9091'
 > icon = 'static/images/apps/transmission.png'

--- a/dashmachine/platform/transmission.py
+++ b/dashmachine/platform/transmission.py
@@ -4,12 +4,12 @@
 Display information from the Trasnmission API
 ```ini
 [variable_name]
-platform = transmission
-host = localhost
-port = 9091
-user = {{ transmission Web UI username }}
-password = {{ Transmission Web UI password }}
-value_template = {{ value_template }}
+platform = 'transmission'
+host = 'localhost'
+port = '9091'
+user = '{{ transmission Web UI username }}'
+password = '{{ Transmission Web UI password }}'
+value_template = '{{ value_template }}'
 ```
 > **Returns:** `value_template` as rendered string
 
@@ -33,22 +33,26 @@ value_template = {{ value_template }}
 * torrentCount
 
 > **Working example:**
->```ini
-> [transmission-data]
-> platform = transmission
-> host = 192.168.1.30
-> port = 9091
-> user = admin
-> password = password123
-> value_template = 🔽 {{(downloadSpeed/1024/1024)|round(2)}} MB/s<br>🔼 {{(uploadSpeed/1024/1024)|round(2)}} MB/s<br><strong>Active:</strong> {{activeTorrentCount}}<br>
->
+>```config/data_sources.toml
+> [transmission_ds]
+> platform = 'transmission'
+> host = '192.168.1.30'
+> port = '9091'
+> user = 'admin'
+> password = 'password123'
+> value_template = '🔽 {{(downloadSpeed/1024/1024)|round(2)}} MB/s<br>🔼 {{(uploadSpeed/1024/1024)|round(2)}} MB/s<br><strong>Active:</strong> {{activeTorrentCount}}<br>'
+```
+
+
+```
+>Dashboard.toml
 > [Transmission]
-> prefix = http://
-> url = 192.168.1.30:9091
-> icon = static/images/apps/transmission.png
-> description = A Fast, Easy, and Free BitTorrent Client
-> open_in = new_tab
-> data_sources = transmission-data
+> prefix = 'http://'
+> url = '192.168.1.30:9091'
+> icon = 'static/images/apps/transmission.png'
+> description = 'A Fast, Easy, and Free BitTorrent Client'
+> open_in = 'new_tab'
+> data_sources = 'transmission_ds'
 >```
 """
 
@@ -62,10 +66,10 @@ import transmissionrpc
 
 
 class Platform:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, options):
         # parse the user's options from the config entries
-        for key, value in kwargs.items():
-            self.__dict__[key] = value
+        for key, value in options.items():
+            setattr(self, key, value)
 
         if not hasattr(self, "port"):
             self.port = 9091


### PR DESCRIPTION
Updated the rest of platforms to include the ' ' on the variables for 0.7.

In "rest.py" I left the following code on Platform init() since unsure:  
  if key == "headers":
    value = json.loads(value)"  

The only doubt I have now in some templates (eg lidarr.py, radarr and sonarr) the value_template has several ' on the same line:  
value_template = '{{error}}Missing    .....  {{diskspace[0]['path']}}) : {{diskspace[0]['free']}} '   
, so not sure if the internals have to be changed to double " :
value_template = '{{error}}Missing    .....  {{diskspace[0]["path"]}}) : {{diskspace[0]["free"]}} '
 