### PR TITLE
Dockerfile: if on arm install deps to compile python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 FROM python:3.8-slim
+RUN apt-get update -q && apt-get install --no-install-recommends -qy inetutils-ping
 
-RUN apt-get update -q \
-  && apt-get install --no-install-recommends -qy \
-    inetutils-ping \
-  && rm -rf /var/lib/apt/lists/*
+# on arm install build dependencies for some python images
+RUN arch=$(uname -m) &&\
+    if [ $arch = "aarch64" ] || [ $arch = "armv7l" ] ; then \
+      apt-get install --no-install-recommends -qy \
+      gcc \
+      build-essential \
+      libffi-dev; \
+    fi
+
+RUN rm -rf /var/lib/apt/lists/*
 
 COPY [ "requirements.txt", "/DashMachine/" ]
 
@@ -11,6 +18,11 @@ WORKDIR /DashMachine
 
 RUN pip install --no-cache-dir --progress-bar off gunicorn
 RUN pip install --no-cache-dir --progress-bar off -r requirements.txt
+
+RUN arch=$(uname -m) &&\
+    if [ $arch = "aarch64" ] || [ $arch = "armv7l" ] ; then \
+      apt-get remove --auto-remove -qy gcc build-essential libffi-dev; \
+    fi
 
 COPY [".", "/DashMachine/"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.8-slim
+
 RUN apt-get update -q && apt-get install --no-install-recommends -qy inetutils-ping
 
 # on arm install build dependencies for some python images


### PR DESCRIPTION
If compiling the dockerfile on arm some deps are needed to build stuff while installing the python packages.
With this changes i was able to use following command to build a multi-arch container.
```bash
docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t manniq31/rmountjoy-dashmachine:latest --push .
```
The compilation took ages on my docker desktop instance on windows but it worked.
